### PR TITLE
feat: add support for videoId query flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@ IPs are rotated every 2 minutes to avoid rate limiting.
 
 ## Example Request
 
-https://ryd-proxy.kavin.rocks/votes/dQw4w9WgXcQ
+### GET - `/votes/dQw4w9WgXcQ`
 
-```js
+```json
+{"id":"dQw4w9WgXcQ","dateCreated":"2022-04-09T22:01:38.222268Z","likes":14589269,"dislikes":390375,"rating":4.8957585373858015,"viewCount":1232906190,"deleted":false}
+```
+
+### GET - `/votes?videoId=dQw4w9WgXcQ`
+
+```json
 {"id":"dQw4w9WgXcQ","dateCreated":"2022-04-09T22:01:38.222268Z","likes":14589269,"dislikes":390375,"rating":4.8957585373858015,"viewCount":1232906190,"deleted":false}
 ```
 

--- a/main.go
+++ b/main.go
@@ -51,15 +51,26 @@ func main() {
 		},
 	)
 
-	app.Get("/votes/:videoId", handler)
+	// Route for /votes?videoId=:videoId
+	app.Get("/votes", handleQuery)
+
+	// Route for /votes/:videoId
+	app.Get("/votes/:videoId", handleParam)
 
 	log.Fatal(app.Listen(":3000"))
 }
 
-func handler(c *fiber.Ctx) error {
+func handleQuery(c *fiber.Ctx) error {
+	videoId := c.Query("videoId")
+	return getVotes(c, videoId)
+}
 
+func handleParam(c *fiber.Ctx) error {
 	videoId := c.Params("videoId")
+	return getVotes(c, videoId)
+}
 
+func getVotes(c *fiber.Ctx, videoId string) error {
 	match, _ := regexp.Match("^([a-zA-Z0-9_-]{11})", []byte(videoId))
 
 	if !match {


### PR DESCRIPTION
Close #14

Small PR what adds support for passing the `videoId` via query flags, allowing RYD-Proxy to be a drop-in replacement for RYD (for fetching votes.)