### PR TITLE
Fix resource leak with http request

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@ IPs are rotated every 2 minutes to avoid rate limiting.
 
 ## Example Request
 
-https://ryd-proxy.kavin.rocks/votes/dQw4w9WgXcQ
+### GET - `/votes/dQw4w9WgXcQ`
 
-```js
+```json
+{"id":"dQw4w9WgXcQ","dateCreated":"2022-04-09T22:01:38.222268Z","likes":14589269,"dislikes":390375,"rating":4.8957585373858015,"viewCount":1232906190,"deleted":false}
+```
+
+### GET - `/votes?videoId=dQw4w9WgXcQ`
+
+```json
 {"id":"dQw4w9WgXcQ","dateCreated":"2022-04-09T22:01:38.222268Z","likes":14589269,"dislikes":390375,"rating":4.8957585373858015,"viewCount":1232906190,"deleted":false}
 ```
 

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func getVotes(c *fiber.Ctx, videoId string) error {
 		return c.Status(400).SendString("Invalid video id")
 	}
 
-	for true {
+	for {
 		req, _ := http.NewRequest("GET", "https://returnyoutubedislikeapi.com/Votes?videoId="+videoId+"&likeCount=", nil)
 
 		req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0")
@@ -95,6 +95,8 @@ func getVotes(c *fiber.Ctx, videoId string) error {
 			continue
 		}
 
+		defer resp.Body.Close()
+
 		ce := resp.Header.Get("Content-Encoding")
 
 		var stream io.Reader
@@ -109,7 +111,4 @@ func getVotes(c *fiber.Ctx, videoId string) error {
 
 		return c.Status(resp.StatusCode).SendStream(stream)
 	}
-
-	// Should never be reached
-	return nil
 }

--- a/main.go
+++ b/main.go
@@ -51,15 +51,26 @@ func main() {
 		},
 	)
 
-	app.Get("/votes/:videoId", handler)
+	// Route for /votes?videoId=:videoId
+	app.Get("/votes", handleQuery)
+
+	// Route for /votes/:videoId
+	app.Get("/votes/:videoId", handleParam)
 
 	log.Fatal(app.Listen(":3000"))
 }
 
-func handler(c *fiber.Ctx) error {
+func handleQuery(c *fiber.Ctx) error {
+	videoId := c.Query("videoId")
+	return getVotes(c, videoId)
+}
 
+func handleParam(c *fiber.Ctx) error {
 	videoId := c.Params("videoId")
+	return getVotes(c, videoId)
+}
 
+func getVotes(c *fiber.Ctx, videoId string) error {
 	match, _ := regexp.Match("^([a-zA-Z0-9_-]{11})", []byte(videoId))
 
 	if !match {


### PR DESCRIPTION
Small PR what fixes a resource leak with the response body from `returnyoutubedislikeapi.com` not being closed.